### PR TITLE
Disable Ray's memory monitor: it kills workers mid-load on UMA Sparks

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -514,6 +514,23 @@ launch_cluster() {
         -e "FLASHINFER_CUDA_ARCH_LIST=$FLASHINFER_CUDA_ARCH_LIST"
         -e FLASHINFER_DISABLE_VERSION_CHECK=1
         -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+        # Ray's memory monitor kills worker actors at 95% NODE memory
+        # (RAY_memory_usage_threshold default 0.95). On a GB10 Spark the 119.7
+        # GiB is UNIFIED, so vLLM's ~100 GiB reservation plus the page cache
+        # needed to stream a 181 GiB checkpoint crosses that line DURING weight
+        # loading. Ray kills the actor, the loading progress bar simply stops,
+        # and it presents as a hang rather than an error — the raylet reason is
+        # only visible as ray.exceptions.OutOfMemoryError buried in the log.
+        #
+        # This does not occur on a pair with nothing else resident, which is
+        # presumably why the published profile does not hit it. It reproduces
+        # reliably on a Spark that also runs an application: five consecutive
+        # launches froze between 40% and 80% of loading, and disabling the
+        # monitor took the same config straight through to serving.
+        #
+        # Safe because --gpu-memory-utilization already bounds the allocation;
+        # this only removes Ray's duplicate, and less informative, guard.
+        -e RAY_memory_monitor_refresh_ms=0
     )
     local worker_nccl="" e
     for e in "${nccl_common[@]}"; do


### PR DESCRIPTION
Thanks for publishing this — it's the only dual-Spark GLM-5.3-Flash recipe out there, and the NCCL/CX7 pinning saved us a lot of time.

We hit one reproducible failure that I don't think your kit can see, because it only appears when a Spark is running something else alongside vLLM.

## Symptom

`Loading safetensors checkpoint shards` stops advancing somewhere between 40% and 80%. No error at the point of failure. The process stays alive, memory sits high, every thread is at ~0% CPU. It reads exactly like an NCCL hang or a slow filesystem, so the instinct is to tune `GPU_MEM_UTIL` — which cannot fix it, and lowering it far enough to load then yields `Available KV cache memory: -2.26 GiB`.

## Cause

Ray's memory monitor kills worker actors at 95% **node** memory (`RAY_memory_usage_threshold` default 0.95). The real reason surfaces only as a buried exception:

```
ray.exceptions.OutOfMemoryError: 1 worker(s) were killed due to the node
running low on memory. Memory on the node (IP: 10.99.0.2) was
113.76GB / 119.70GB (0.950345)
```

On GB10 the 119.7 GiB is **unified**, so vLLM's ~100 GiB reservation at `GPU_MEM_UTIL=0.84` plus the page cache needed to stream the 181.29 GiB checkpoint crosses 95% during loading. A dedicated-VRAM box doesn't have this problem: weights stream through separate host RAM. A bare Spark pair mostly avoids it too — which is presumably why your published profile is clean.

## Evidence

Five consecutive launches froze between 40% and 80%. Adding this single variable took the *same* configuration through to a healthy server:

```
Model loading took 91.23 GiB and 631.23 seconds
Available KV cache memory: 4.89 GiB
GPU KV cache size: 283,346 tokens
```

## Why it's safe

`--gpu-memory-utilization` already bounds the allocation. This only removes Ray's duplicate guard, which is redundant here and considerably less informative when it fires — a kernel OOM at least reports itself.

## Qualified on

2× DGX Spark (GB10, SM121, 119.7 GiB unified each) over CX7 at TP=2, with one node also hosting a Postgres + Qdrant + embedding stack. Settings that worked for us on that footprint: `GPU_MEM_UTIL=0.85`, `MAX_NUM_SEQS=4`, `MAX_MODEL_LEN=65536`, ~24 tok/s single stream.

Two smaller notes in case they're useful for the README, no change requested:

- `HEAD_CX7_IF` / `HEAD_CX7_IB` default to `enp1s0f1np1` / `rocep1s0f1` while the worker defaults to `enp1s0f0np0` / `rocep1s0f0`. Both our Sparks present the same names on both sides, so the head defaults pin NCCL to a down interface — exactly the hang the README warns about.
- `chat_template_kwargs: {"enable_thinking": false}` doesn't suppress reasoning on this checkpoint; it leaks the reasoning into `content`. `reasoning_effort: "low"` does work (2727 → 36 chars of reasoning, clean output), which matters a lot for structured-output callers.