### PR TITLE
Pass VLLM_API_KEY through to head and worker containers

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -540,7 +540,7 @@ launch_cluster() {
     # optional extra passthrough
     local worker_passthru="" v val
     local -a head_env=()
-    for v in HF_HUB_OFFLINE; do
+    for v in HF_HUB_OFFLINE VLLM_API_KEY; do
         val="${!v:-}"
         if [ -n "$val" ]; then
             head_env+=(-e "$v=$val")


### PR DESCRIPTION
## Summary
- Adds `VLLM_API_KEY` to the existing env-passthrough loop in `start.sh` (previously only `HF_HUB_OFFLINE` was forwarded), so setting the standard vLLM auth env var on the host actually reaches both containers.

## Why this mechanism
- The passthrough loop injects the value via `docker -e`, keeping the secret out of process arguments, the generated launcher text, and startup logs.
- We use this exact change in the [PixelML fork](https://github.com/PixelML/GLM-5.3-Flash-NVFP4-Dual-DGX-Spark) to serve GLM-5.3-Flash-NVFP4 with API auth across two DGX Sparks.

## Testing
- `bash -n start.sh` passes.
- Verified on our dual-DGX-Spark pair: with `VLLM_API_KEY` set, unauthenticated requests are rejected and Bearer-authenticated requests succeed; without it, behavior is unchanged.